### PR TITLE
Update externallib.php

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -326,7 +326,7 @@ class local_ws_enrolcohort_external extends external_api {
         $extradata[] = (new responses\cohort($cohortid))->to_array();
 
         // Get the available cohorts.
-        $availablecohorts = cohort_get_available_cohorts($context);
+        $availablecohorts = cohort_get_available_cohorts($context, 0, 0, 0);
         if (empty($availablecohorts) || !isset($availablecohorts[$cohortid])) {
             throw new cohort_not_available_at_context_exception($cohortid);
         }


### PR DESCRIPTION
If the zeros (especially the last one) are not set when calling `cohort_get_available_cohorts`, then only the first 25 cohorts are returned, as this is hardcoded in `cohort_get_available_cohorts` in Moodles `cohort/lib.php`
This change makes sure, that there is no limit when collecting all cohorts of a context.
Of course for a big number of cohorts this might have an impact on performance (so maybe a very high limit makes sense).
But even then a different error message should be issued.