### PR TITLE
Add github actions and ci file for updating moodle plugins db

### DIFF
--- a/.github/workflows/moodle-ci.yaml
+++ b/.github/workflows/moodle-ci.yaml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:9.6
+        image: postgres:latest
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'

--- a/.github/workflows/moodle-ci.yaml
+++ b/.github/workflows/moodle-ci.yaml
@@ -20,16 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '7.3'
+          - php: '7.2'
             moodle-branch: 'MOODLE_39_STABLE'
             extensions: mbstring
-          - php: '7.3'
+          - php: '7.2'
             moodle-branch: 'MOODLE_310_STABLE'
             extensions: mbstring
-          - php: '7.4'
+          - php: '7.3'
             moodle-branch: 'MOODLE_311_STABLE'
             extensions: [sodium, mbstring]
-          - php: '7.4'
+          - php: '7.3'
             moodle-branch: 'MOODLE_400_STABLE'
             extensions: [sodium, mbstring, exif]
 

--- a/.github/workflows/moodle-ci.yaml
+++ b/.github/workflows/moodle-ci.yaml
@@ -22,10 +22,16 @@ jobs:
         include:
           - php: '7.3'
             moodle-branch: 'MOODLE_39_STABLE'
+            extensions: mbstring
           - php: '7.3'
             moodle-branch: 'MOODLE_310_STABLE'
+            extensions: mbstring
           - php: '7.4'
             moodle-branch: 'MOODLE_311_STABLE'
+            extensions: [sodium, mbstring]
+          - php: '7.4'
+            moodle-branch: 'MOODLE_400_STABLE'
+            extensions: [sodium, mbstring, exif]
 
     steps:
       - name: Check out repository code
@@ -37,6 +43,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          ini-values: max_input_vars=5000
           coverage: none
 
       - name: Initialise moodle-plugin-ci

--- a/.github/workflows/moodle-ci.yaml
+++ b/.github/workflows/moodle-ci.yaml
@@ -69,9 +69,6 @@ jobs:
       - name: Run phpmd
         run: moodle-plugin-ci phpmd
 
-      - name: Run codechecker
-        run: moodle-plugin-ci codechecker
-
       - name: Run validate
         run: moodle-plugin-ci validate
 

--- a/.github/workflows/moodle-ci.yaml
+++ b/.github/workflows/moodle-ci.yaml
@@ -60,9 +60,30 @@ jobs:
           DB: pgsql
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
 
+      - name: Run phplint
+        run: moodle-plugin-ci phplint
+
+      - name: Run phpcpd
+        run: moodle-plugin-ci phpcpd || true
+
+      - name: Run phpmd
+        run: moodle-plugin-ci phpmd
+
+      - name: Run codechecker
+        run: moodle-plugin-ci codechecker
+
+      - name: Run validate
+        run: moodle-plugin-ci validate
+
+      - name: Run savepoints
+        run: moodle-plugin-ci savepoints
+
       - name: Grunt
         if: ${{ always() }}
         run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: Run phpdoc
+          run: moodle-plugin-ci phpdoc
 
       - name: PHPUnit tests
         if: ${{ always() }}

--- a/.github/workflows/moodle-ci.yaml
+++ b/.github/workflows/moodle-ci.yaml
@@ -78,12 +78,8 @@ jobs:
       - name: Run savepoints
         run: moodle-plugin-ci savepoints
 
-      - name: Grunt
-        if: ${{ always() }}
-        run: moodle-plugin-ci grunt --max-lint-warnings 0
-
       - name: Run phpdoc
-          run: moodle-plugin-ci phpdoc
+        run: moodle-plugin-ci phpdoc
 
       - name: PHPUnit tests
         if: ${{ always() }}

--- a/.github/workflows/moodle-ci.yaml
+++ b/.github/workflows/moodle-ci.yaml
@@ -75,9 +75,6 @@ jobs:
       - name: Run savepoints
         run: moodle-plugin-ci savepoints
 
-      - name: Run phpdoc
-        run: moodle-plugin-ci phpdoc
-
       - name: PHPUnit tests
         if: ${{ always() }}
         run: moodle-plugin-ci phpunit --coverage-text

--- a/.github/workflows/moodle-ci.yaml
+++ b/.github/workflows/moodle-ci.yaml
@@ -1,0 +1,62 @@
+name: moodle-plugin-ci
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:9.6
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.3'
+            moodle-branch: 'MOODLE_39_STABLE'
+          - php: '7.3'
+            moodle-branch: 'MOODLE_310_STABLE'
+          - php: '7.4'
+            moodle-branch: 'MOODLE_311_STABLE'
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: pgsql
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --coverage-text

--- a/.github/workflows/moodle-release.yaml
+++ b/.github/workflows/moodle-release.yaml
@@ -3,7 +3,7 @@
 # Thanks https://github.com/danmarsden :)
 #
 
-name: moodle-plugin-ci
+name: Releasing in the Plugins directory
 
 on:
   push:

--- a/.github/workflows/moodle-release.yaml
+++ b/.github/workflows/moodle-release.yaml
@@ -1,0 +1,119 @@
+#
+# Whenever version.php is changed, add to Moodle Plugins directory at https://moodle.org/plugins.
+# Thanks https://github.com/danmarsden :)
+#
+
+name: moodle-plugin-ci
+
+on:
+  push:
+    paths:
+      - 'version.php'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.2'
+            moodle-branch: 'MOODLE_39_STABLE'
+            extensions: mbstring
+          - php: '7.2'
+            moodle-branch: 'MOODLE_310_STABLE'
+            extensions: mbstring
+          - php: '7.3'
+            moodle-branch: 'MOODLE_311_STABLE'
+            extensions: [sodium, mbstring]
+          - php: '7.3'
+            moodle-branch: 'MOODLE_400_STABLE'
+            extensions: [sodium, mbstring, exif]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: pgsql
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: Run phplint
+        run: moodle-plugin-ci phplint
+
+      - name: Run phpcpd
+        run: moodle-plugin-ci phpcpd || true
+
+      - name: Run phpmd
+        run: moodle-plugin-ci phpmd
+
+      - name: Run validate
+        run: moodle-plugin-ci validate
+
+      - name: Run savepoints
+        run: moodle-plugin-ci savepoints
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --coverage-text
+
+      - name: Release at Moodle.org by calling the service function
+        id: add-version
+        env:
+          PLUGIN: local_ws_enrolcohort
+          BRANCH: master
+          CURL: curl -s
+          ENDPOINT: https://moodle.org/webservice/rest/server.php
+          TOKEN: ${{ secrets.MOODLE_ORG_TOKEN }}
+          FUNCTION: local_plugins_add_version
+
+        run: |
+          ZIPURL="https://github.com/emyb/moodle-local_ws_enrolcohort/archive/refs/heads/${BRANCH}.zip"
+          RESPONSE=$(${CURL} ${ENDPOINT} --data-urlencode "wstoken=${TOKEN}" \
+                                         --data-urlencode "wsfunction=${FUNCTION}" \
+                                         --data-urlencode "moodlewsrestformat=json" \
+                                         --data-urlencode "frankenstyle=${PLUGIN}" \
+                                         --data-urlencode "zipurl=${ZIPURL}" \
+                                         --data-urlencode "vcssystem=git" \
+                                         --data-urlencode "vcsrepositoryurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+                                         --data-urlencode "vcstag=${TAGNAME}" \
+                                         --data-urlencode "changelogurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${BRANCH}/CHANGELOG.md" \
+                                         --data-urlencode "altdownloadurl=${ZIPURL}")
+          echo "::set-output name=response::${RESPONSE}"
+      - name: Evaluate the response
+        id: evaluate-response
+        env:
+          RESPONSE: ${{ steps.add-version.outputs.response }}
+        run: |
+          jq <<< ${RESPONSE}
+          jq --exit-status ".id" <<< ${RESPONSE} > /dev/null

--- a/.github/workflows/moodle-release.yaml
+++ b/.github/workflows/moodle-release.yaml
@@ -28,15 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '7.2'
-            moodle-branch: 'MOODLE_39_STABLE'
-            extensions: mbstring
-          - php: '7.2'
-            moodle-branch: 'MOODLE_310_STABLE'
-            extensions: mbstring
-          - php: '7.3'
-            moodle-branch: 'MOODLE_311_STABLE'
-            extensions: [sodium, mbstring]
           - php: '7.3'
             moodle-branch: 'MOODLE_400_STABLE'
             extensions: [sodium, mbstring, exif]

--- a/.github/workflows/moodle-release.yaml
+++ b/.github/workflows/moodle-release.yaml
@@ -89,7 +89,7 @@ jobs:
           FUNCTION: local_plugins_add_version
 
         run: |
-          ZIPURL="https://github.com/emyb/moodle-local_ws_enrolcohort/archive/refs/heads/${BRANCH}.zip"
+          ZIPURL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/archive/refs/heads/${BRANCH}.zip"
           RESPONSE=$(${CURL} ${ENDPOINT} --data-urlencode "wstoken=${TOKEN}" \
                                          --data-urlencode "wsfunction=${FUNCTION}" \
                                          --data-urlencode "moodlewsrestformat=json" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,26 @@
 # Moodle Webservices for Cohort Enrolment CHANGELOG.
+This change log is not following the format based on Keep a Changelog... yet. 
 
 Version history:
 
-v3.3.2 (20180600)
+## [v3.3.4] - 2022062800
+
+* Finally added github actions for testing against multiple moodle versions and environments
+* Added a thing for uploading to Moodle Plugins database when the version file is changed. Be careful!!! Thanks [@danmarsden](https://github.com/danmarsden)
+* Moved the things around in the change log so that the latest change is at the top :)
+* Hmmm...
+
+## [v3.3.3] - 2019042900
+for Moodle 3.3, 3.4, 3.5, and 3.6. Released Monday, 29 April 2019
+
+* Fixed issue that was preventing a cohort enrolment instance being added to a course.
+  * This was happening for sites that had more than 25 cohorts available at a context. This limit is a default value when calling cohort_get_available_cohorts().
+  * Thanks to Thomas (thoschi) for this fix.
+* Updated unit tests to create 100 cohorts before calling the webservice add_instance() function.
+* Tagged this release.
+
+## [v3.3.2] - 20180600
+In the very beginning!!!
 
 * Added additional check in php unit test delete instance to ensure that the cohort enrolment instance was removed.
 * Implemented privacy API.
-
-v3.3.3 (2019042900) for Moodle 3.3, 3.4, 3.5, and 3.6. Released Monday, 29 April 2019
-
-* Fixed issue that was preventing a cohort enrolment instance being added to a course.
-    * This was happening for sites that had more than 25 cohorts available at a context. This limit is a default value when calling cohort_get_available_cohorts().
-    * Thanks to Thomas (thoschi) for this fix.
-* Updated unit tests to create 100 cohorts before calling the webservice add_instance() function.
-* Tagged this release.

--- a/version.php
+++ b/version.php
@@ -31,8 +31,8 @@ $plugin->requires = 2017051500;
 
 // Plugin details.
 $plugin->component  = 'local_ws_enrolcohort';
-$plugin->version    = 2019042900;   // Plugin updated April 29, 2019.
-$plugin->release    = 'v3.3.3';
+$plugin->version    = 2022062800;   // Plugin updated June 2022.
+$plugin->release    = 'v3.3.4';
 
 // Plugin status details.
 $plugin->maturity = MATURITY_STABLE;   // ALPHA, BETA, RC, STABLE.


### PR DESCRIPTION
Added github actions file to automatically deploy version changes to the moodle plugins db.

@Jay-Liya, if you do get to merge this in, you will have to setup secrets in the code repository (see https://docs.github.com/en/actions/security-guides/encrypted-secrets) Otherwise I can try to maintain it